### PR TITLE
feat(notifications): Topic/Predicate subscriptions changes

### DIFF
--- a/intergov/processors/callback_deliver/__init__.py
+++ b/intergov/processors/callback_deliver/__init__.py
@@ -29,7 +29,7 @@ class CallbacksDeliveryProcessor(object):
         self._prepare_use_cases()
 
     def __iter__(self):
-        logger.info("Starting the outbound callbacks processor")
+        logger.info("Starting the outbound callbacks deliverer")
         return self
 
     def __next__(self):

--- a/intergov/processors/callbacks_spreader/__init__.py
+++ b/intergov/processors/callbacks_spreader/__init__.py
@@ -56,7 +56,7 @@ class CallbacksSpreaderProcessor(object):
         self._prepare_use_cases()
 
     def __iter__(self):
-        logger.info("Starting the outbound callbacks processor")
+        logger.info("Starting the outbound callbacks spreader")
         return self
 
     def __next__(self):

--- a/intergov/repos/subscriptions/minio/miniorepo.py
+++ b/intergov/repos/subscriptions/minio/miniorepo.py
@@ -45,16 +45,27 @@ class SubscriptionsRepo(miniorepo.MinioRepo):
         if not predicate_pattern:
             raise ValueError("non-empty predicate is required")
         if '/' in predicate_pattern:
-            raise ValueError("predicate should contain dots, not slashes")
-        if predicate_pattern.endswith('.'):
-            # drop the pointless dot at the end
-            predicate_pattern = predicate_pattern[:-1]
-        if predicate_pattern.endswith('*'):
-            # drop the pointless dot at the end
-            predicate_pattern = predicate_pattern[:-1]
-            assert predicate_pattern.endswith('.'), "* character is supported only after a dot"
-        predicate_parts = predicate_pattern.upper().split('.')
-        return '/'.join([p for p in predicate_parts if p]) + '/'
+            # predicate is a topic
+            topic_pattern = predicate_pattern
+            predicate_pattern = None
+        else:
+            # predicate is a predicate
+            topic_pattern = None
+        if predicate_pattern:
+            if predicate_pattern.endswith('.'):
+                # drop the pointless dot at the end
+                predicate_pattern = predicate_pattern[:-1]
+            if predicate_pattern.endswith('*'):
+                predicate_pattern = predicate_pattern[:-1]
+                assert predicate_pattern.endswith('.'), "* character is supported only in the last part"
+            predicate_parts = predicate_pattern.upper().split('.')
+            return '/'.join([p for p in predicate_parts if p]) + '/'
+        elif topic_pattern:
+            topic_pattern = topic_pattern.strip("/")
+            if topic_pattern.endswith('*'):
+                topic_pattern = topic_pattern[:-1]
+                assert topic_pattern.endswith('/'), "* character is supported only in the last part"
+            return topic_pattern
 
     def _pattern_to_layers(self, predicate_pattern):
         layers = []

--- a/tests/unit/repos/subscriptions/test.py
+++ b/tests/unit/repos/subscriptions/test.py
@@ -32,9 +32,9 @@ def test_repo_utils(boto3, datetime_mock):
     # error should be not empty
     with pytest.raises(ValueError):
         repo._pattern_to_key('')
-    # error should not contain slashes
-    with pytest.raises(ValueError):
-        repo._pattern_to_key('aa/bb')
+    # # error should not contain slashes UPD: it's fine now
+    # with pytest.raises(ValueError):
+    #     repo._pattern_to_key('aa/bb')
     assert repo._pattern_to_key('aaaa.bbbb.cccc') == "AAAA/BBBB/CCCC/"
     assert repo._pattern_to_key('aaaa.bbbb.cccc.*') == repo._pattern_to_key('aaaa.bbbb.cccc')
     assert repo._pattern_to_key('aaaa.bbbb.cccc.') == repo._pattern_to_key('aaaa.bbbb.cccc')


### PR DESCRIPTION
* Support /topic/format as well as the predicate.format
* send per-message notifications to topics instead of predicates
* leave per-message predicate notifications for the time being

Support both topic and predicate workflows and subscribe them better for the per-message topics