### PR TITLE
feat(message_api): Ability for message update worker to use message a…

### DIFF
--- a/demo-default.env
+++ b/demo-default.env
@@ -89,3 +89,6 @@ IGL_MCHR_ROUTING_TABLE=[{ "Name": "shared db channel to Australia", "Jurisdictio
 
 # Ideally these client id, secrets and other channel-specific values should be included in the
 # channel ocnf along with "ChannelAuth" parameter somehow, but it's postponed
+
+IGL_PROC_BCH_MESSAGE_API_ENDPOINT=http://message_api/message/{sender}:{sender_ref}
+IGL_PROC_BCH_MESSAGE_API_ENDPOINT_AUTH=none

--- a/intergov/apis/common/interapi_auth.py
+++ b/intergov/apis/common/interapi_auth.py
@@ -1,0 +1,116 @@
+import binascii
+import base64
+import datetime
+from functools import lru_cache
+
+import requests
+
+from intergov.loggers import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AuthMixin:
+    """
+    In the general use-case our APIs should use some auth talking to other
+    APIs, so we need to retrieve correct credentials based on env variables
+    configuration
+    """
+
+    def _get_auth_headers(self, auth_method, auth_parameters=None):
+        # for auth_method "none" there are no auth_parameters read
+        # for auth_method Cognito/JWT it must be a dict of format:
+        #  {"client_id": "1", "client_secret": "2", "scopes": "3", "wellknown_url": "4"}
+        if auth_method == "none":
+            # no auth - local/test setups
+            return {}
+        elif auth_method == "Cognito/JWT":
+            assert auth_parameters, "auth_parameters must be configured correctly"
+            assert "client_id" in auth_parameters, "auth_parameters must be configured correctly"
+            assert "client_secret" in auth_parameters, "auth_parameters must be configured correctly"
+            return {
+                "Authorization": "Bearer " + self._get_cached_cognito_jwt(
+                    auth_parameters
+                )
+            }
+        else:
+            raise Exception(
+                f"Improperly configured: "
+                f"unsupported auth mechanism {auth_method}"
+            )
+
+    def _get_cached_cognito_jwt(self, auth_parameters):
+        """
+        This is implementation-specific procedure. Good thing - it's useful
+        and will be used for our test installations.
+        Bad thing - it's really cognito-specific. In fact it could be easily
+        changed to generic OIDC IDP.
+        Good thing - it could be moved to a subclass easily, preserving the core
+        intergov pureness
+        """
+        cache_key = str(binascii.crc32(str(auth_parameters).encode("utf-8")))
+        old_token_exp = getattr(self, f"_cognito_jwt_expiration_date_{cache_key}", None)
+        old_token_value = getattr(self, f"_cognito_jwt_{cache_key}", None)
+
+        if old_token_exp and old_token_exp < datetime.datetime.utcnow():
+            old_token_value = None
+
+        if old_token_value:
+            # cache hit
+            return old_token_value
+
+        new_token, expires = self._issue_cognito_jwt(auth_parameters)
+        setattr(
+            self,
+            f"_cognito_jwt_{cache_key}",
+            new_token
+        )
+        if expires < 60:
+            seconds_to_renew = int(expires / 2)
+        else:
+            seconds_to_renew = expires - 60
+        setattr(
+            self,
+            f'_cognito_jwt_expiration_date_{cache_key}',
+            (
+                datetime.datetime.utcnow() + datetime.timedelta(seconds=seconds_to_renew)
+            )
+        )
+        return new_token
+
+    def _issue_cognito_jwt(self, auth_parameters):
+        # see _get_cached_cognito_jwt descr about the design concerns
+        OAUTH_CLIENT_ID = auth_parameters["client_id"]
+        OAUTH_CLIENT_SECRET = auth_parameters["client_secret"]
+        OAUTH_SCOPES = auth_parameters["scopes"]
+
+        cognito_auth = base64.b64encode(
+            f"{OAUTH_CLIENT_ID}:{OAUTH_CLIENT_SECRET}".encode("utf-8")
+        ).decode("utf-8")
+        token_resp = requests.post(
+            auth_parameters.get("token_endpoint") or _oidc_token_url(auth_parameters["wellknown_url"]),
+            data={
+                "grant_type": "client_credentials",
+                "client_id": OAUTH_CLIENT_ID,
+                "scope": OAUTH_SCOPES,
+            },
+            headers={
+                'Authorization': f'Basic {cognito_auth}',
+            }
+        )
+        assert token_resp.status_code == 200, token_resp.json()
+        json_resp = token_resp.json()
+        logger.info(
+            "The new JWT for %s ends in %s",
+            auth_parameters["client_id"],
+            json_resp['expires_in']
+        )
+        return json_resp["access_token"], json_resp['expires_in']
+
+
+@lru_cache(maxsize=2)  # it's fine to cache for a long time
+def _oidc_token_url(wellknown_url):
+    # see _get_cached_cognito_jwt descr about the design concerns
+    wellknown_content = requests.get(wellknown_url)
+    assert wellknown_content.status_code == 200
+    return wellknown_content.json().get("token_endpoint")

--- a/intergov/processors/common/env.py
+++ b/intergov/processors/common/env.py
@@ -1,9 +1,24 @@
-from intergov.conf import env
+from intergov.conf import env, env_json
 
 MESSAGE_PATCH_API_ENDPOINT = env(
     'IGL_PROC_BCH_MESSAGE_API_ENDPOINT',
     default='http://message_api/message/{sender}:{sender_ref}'
 )
+MESSAGE_PATCH_API_ENDPOINT_AUTH = env(
+    "IGL_PROC_BCH_MESSAGE_API_ENDPOINT_AUTH",
+    default="Cognito/JWT"
+)
+MESSAGE_PATCH_API_ENDPOINT_AUTH_PARAMS = None
+
+if MESSAGE_PATCH_API_ENDPOINT_AUTH == "Cognito/JWT":
+    # These env variables may change in the future
+    JRD = env("IGL_COUNTRY")
+    MESSAGE_PATCH_API_ENDPOINT_AUTH_PARAMS = {
+        "client_id": env_json("IGL_COUNTRY_OAUTH_CLIENT_ID")[JRD],
+        "client_secret": env_json("IGL_COUNTRY_OAUTH_CLIENT_SECRET")[JRD],
+        "scopes": env_json("IGL_COUNTRY_OAUTH_SCOPES")[JRD],
+        "wellknown_url": env_json("IGL_COUNTRY_OAUTH_WELLKNOWN_URL")[JRD],
+    }
 
 
 MESSAGE_RX_API_ENDPOINT = env(

--- a/intergov/processors/message_updater/__init__.py
+++ b/intergov/processors/message_updater/__init__.py
@@ -1,18 +1,21 @@
 import time
 import requests
 from http import HTTPStatus
+from intergov.apis.common.interapi_auth import AuthMixin
 from intergov.conf import env_queue_config
-from intergov.repos.message_updates import MessageUpdatesRepo
 from intergov.domain.wire_protocols import generic_discrete as gd
+from intergov.repos.message_updates import MessageUpdatesRepo
 from intergov.loggers import logging
 from intergov.processors.common.env import (
-    MESSAGE_PATCH_API_ENDPOINT
+    MESSAGE_PATCH_API_ENDPOINT,
+    MESSAGE_PATCH_API_ENDPOINT_AUTH,
+    MESSAGE_PATCH_API_ENDPOINT_AUTH_PARAMS,
 )
 
-logger = logging.getLogger('channel_message_updater')
+logger = logging.getLogger('message_updater')
 
 
-class MessageUpdater(object):
+class MessageUpdater(AuthMixin, object):
     """
     Iterate over message update jobs:
 
@@ -25,15 +28,34 @@ class MessageUpdater(object):
     # maybe also put the "update job" into a request model
     # TODO: tar-pit algorithm on retrys?
     # (prevent thundering herd after outage)
+
     def _prepare_message_updates_repo(self, conf):
         message_updates_repo_conf = env_queue_config('BCH_MESSAGE_UPDATES')
         if conf:
             message_updates_repo_conf.update(conf)
         self.message_updates_repo = MessageUpdatesRepo(message_updates_repo_conf)
 
+    def _get_headers_for_message_api(self):
+        result = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        if MESSAGE_PATCH_API_ENDPOINT_AUTH == "none":
+            auth_parameters = None
+        elif MESSAGE_PATCH_API_ENDPOINT_AUTH == "Cognito/JWT":
+            auth_parameters = MESSAGE_PATCH_API_ENDPOINT_AUTH_PARAMS
+        else:
+            raise Exception(f"Unsupported endpoint auth {MESSAGE_PATCH_API_ENDPOINT_AUTH}")
+        result.update(self._get_auth_headers(
+            auth_method=MESSAGE_PATCH_API_ENDPOINT_AUTH,
+            # auth well known urls and other configuration
+            auth_parameters=auth_parameters
+        ))
+        return result
+
     def _patch_message(self, job):
         msg = job['message']
-        patch = job['patch']
+        patch_payload = job['patch']
         retry = job.get('retry', 0)
         retry_max = job.get('retry_max', 2)
         sender = msg[gd.SENDER_KEY]
@@ -42,14 +64,15 @@ class MessageUpdater(object):
             'Patching message[sender:%s, sender_ref:%s, patch:%s]',
             sender,
             sender_ref,
-            patch
+            patch_payload
         )
         resp = requests.patch(
             MESSAGE_PATCH_API_ENDPOINT.format(
                 sender=sender,
                 sender_ref=sender_ref
             ),
-            json=patch
+            json=patch_payload,
+            headers=self._get_headers_for_message_api(),
         )
         if resp.status_code == HTTPStatus.NOT_FOUND:
             if retry + 1 > retry_max:


### PR DESCRIPTION
…pi with auth

* tried to do it more or less universal (we will see when more workers need it)
* use existing env variables format
* support dumb (local) auth and Cognito/JWT

I'm not so happy about the code placement and the whole configuration approach (may not be as logical and transparent as it could be) but it works at least... and some code is duplicated with the HTTP Channel API but it's also not a big deal while these 2 things are more or less separate.